### PR TITLE
Fix layout issues in homepage and all page

### DIFF
--- a/_layouts/transcript.html
+++ b/_layouts/transcript.html
@@ -100,12 +100,16 @@ endcapture -%}
         {% if page.object-id == 'all' %}
         {% for transcript in site.data.transcripts %}{%assign transcript-name = transcript[0] %}
         {% for item in transcript[1] %}
-        <div id="{{page.object-id}}{{ forloop.index }}" class="{%- assign tags = item.tags | split: ";" | compact | where_exp: 'item', 'item != " "' %}{% for tag in tags %}{{tag | slugify }} {% endfor %} row line my-3">
-          <div class="linenum col-1 small mt-2"><a href="{{ forloop.index | prepend: transcript-name | prepend: '.html#' | prepend: transcript-name | prepend: '/transcripts/' | relative_url }}">{{transcript-name}}-{{ forloop.index }}</a></div>
-          <p class="words col-10 col-md-8 col-print-10 my-3">
-            {%if item.speaker%}{{item.speaker | remove: ":"}}: {%endif%}{{item.words}}
-          </p>
+        {% assign prev_index = forloop.index0 | times: 1 | minus: 1 %}
+        {% assign prev_speaker = items[prev_index].speaker %}
+        {% assign mod = forloop.index | plus: 1 | modulo: 5 %}
+        <div id="{{page.object-id}}{{ forloop.index }}" class="{%- assign tags = item.tags | split: ";" | compact | where_exp: 'item', 'item != " "' %}{% for tag in tags %}{{tag | slugify }} {% endfor %} row line my-1">
 
+          <p class="words col-md-10 col-lg-8 col-print-12 pr-0">
+
+            {% unless item.speaker == prev_speaker %}{%if item.speaker %}<span class="fw-bold pe-3 pb-3">{{item.speaker | remove:
+              ":"}}:</span>{% endif %}{% endunless %}{{item.words}}
+          </p>
         </div>
         {% endfor %}{% endfor %}
         {% else %}

--- a/_layouts/transcript.html
+++ b/_layouts/transcript.html
@@ -106,9 +106,9 @@ endcapture -%}
         <div id="{{page.object-id}}{{ forloop.index }}" class="{%- assign tags = item.tags | split: ";" | compact | where_exp: 'item', 'item != " "' %}{% for tag in tags %}{{tag | slugify }} {% endfor %} row line my-1">
 
           <p class="words col-md-10 col-lg-8 col-print-12 pr-0">
-
-            {% unless item.speaker == prev_speaker %}{%if item.speaker %}<span class="fw-bold pe-3 pb-3">{{item.speaker | remove:
-              ":"}}:</span>{% endif %}{% endunless %}{{item.words}}
+            
+            {% unless item.speaker == prev_speaker %}{%if item.speaker %}<span class="fw-bold pe-3 pb-3"><a href="{{ forloop.index | prepend: transcript-name | prepend: '.html#' | prepend: transcript-name | prepend: '/transcripts/' | relative_url }}" class="text-dark hover-underline">{{item.speaker | remove:
+              ":"}}:</a></span>{% endif %}{% endunless %}{{item.words}} 
           </p>
         </div>
         {% endfor %}{% endfor %}

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -93,3 +93,7 @@ element {
 .btn-outline-dark:hover {
   background-color: #212529 !important;
 }
+
+.hover-underline{
+  &:hover {text-decoration: underline;}
+}

--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@ layout: cover
     {% assign rect-height = 100 | divided_by: height_float  %}
     {%assign transcript-name = transcript[0] %}
     <div class="vizdiv" style="height:{{rect-height}}%">
-      <a href="{{ '/subjects.html/' | relative_url }}"><svg class="chart {{transcript-name}}" width="100%" height="20" style="overflow: visible">
+      <a href="{{ '/subjects.html' | relative_url }}"><svg class="chart {{transcript-name}}" width="100%" height="20" style="overflow: visible">
         {% for item in transcript[1] %}
         {% assign my_integer = forloop.length %}
         {% assign my_float = my_integer | times: 1.0 %}


### PR DESCRIPTION
Hi @tanyaclement , 

The following Pull Request will fix a typo on the homepage of your collection so clicking on the image goes to "subject.html" not "subjects.html/"

The other edit will make the interaction on the all.html page the same as it is on individual pages, meaning the non-pertinent text will be reduced in size rather than removed. 

A note on the latter change -- I am likely going to change that interaction to work more like the text-string search in the future. That means that the non-pertinent text will be muted by class "text-muted" and the pertinent text will be highlighted in light blue. 

Thanks for using OHD!
Devin